### PR TITLE
do not trigger a reload

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -7,10 +7,11 @@ if [ "$1" = configure ] ; then
     if [ -z "$2" ] ; then
 	a2enmod -q rpaf
     fi
-# only restart if mod_rpaf is enabled
-    if [ -e /etc/apache2/mods-enabled/rpaf.load ] ; then
-	invoke-rc.d apache2 restart
-    fi
+# 2015-09-18 - hansr - this interferes with service restart as done by our provisioning software
+# org: only restart if mod_rpaf is enabled
+#    if [ -e /etc/apache2/mods-enabled/rpaf.load ] ; then
+#   invoke-rc.d apache2 restart
+#    fi
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
Reload the apache service is handled by Puppet and will occur when our own `rpaf.load` file is set in `mods-enabled`. Letting the service restart upon installation of this package, messes up Puppet's flow and, besides crashing the Puppet run, leaves the package in a faulty installed state.
